### PR TITLE
Require two comittee members to approve in all cases

### DIFF
--- a/proposals/0003-pr-process.md
+++ b/proposals/0003-pr-process.md
@@ -16,7 +16,7 @@ PRs fall into two categories:
 
   2. Uncontroversial: everything else like technical tweaks, adding new links/resources and bringing website content up to date.
 
-     Uncontroversial changes can be approved by either one committee member who did not work on the PR or two members who worked on a PR together.
+     Uncontroversial changes require the approval of two committee members.  Even if one or more committee members worked on the PR their approval still counts towards the total.
 
 Ultimately, whether or not a change is potentially controversial is a judgement call. Committee members should feel free to hold off on approving and merging PRs if they are unsure or want more input and discussion, and PRs should not be merged if any committee member actively disagrees with the change. If two or more committee members can't agree on a PR, the issue should be brought up to the whole committee.
 

--- a/proposals/0003-pr-process.md
+++ b/proposals/0003-pr-process.md
@@ -12,11 +12,11 @@ PRs fall into two categories:
 
   1. Potentially controversial: changes to website content that people in the community feel strongly about. This includes changes that endorse or highlight specific projects, tools or organizations as well as anything else that might spark or require community discussion.
 
-    Potentially controversial changes should be brought to the full committee for a vote, potentially with other steps (like a community-wide request for comments).
+     Potentially controversial changes should be brought to the full committee for a vote, potentially with other steps (like a community-wide request for comments).
 
   2. Uncontroversial: everything else like technical tweaks, adding new links/resources and bringing website content up to date.
 
-    Uncontroversial changes can be approved by either one committee member who did not work on the PR or two members who worked on a PR together.
+     Uncontroversial changes can be approved by either one committee member who did not work on the PR or two members who worked on a PR together.
 
 Ultimately, whether or not a change is potentially controversial is a judgement call. Committee members should feel free to hold off on approving and merging PRs if they are unsure or want more input and discussion, and PRs should not be merged if any committee member actively disagrees with the change. If two or more committee members can't agree on a PR, the issue should be brought up to the whole committee.
 


### PR DESCRIPTION
The current wording makes it easier for a non-committee member to get a PR merged than a committee member! A non-committee member has 7 possible approvers whereas a committee member has only 6.

I suggest we deal with this by requiring two approvals in all cases *even if the approvals come from committee members who worked on the PR*.

cc @TikhonJelvis @rebeccaskinner @jaspervdj @ryantrinkle @romefeller @idabzo